### PR TITLE
build: Update pre-commit hooks version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,112 +1,112 @@
 ---
 repos:
-    - repo: https://github.com/adrienverge/yamllint.git
-      rev: v1.35.1
-      hooks:
-          - id: yamllint
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
 
-    - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
-      rev: 0.2.3
-      hooks:
-          - id: yamlfmt
+  - repo: https://github.com/jumanjihouse/pre-commit-hook-yamlfmt
+    rev: 0.2.3
+    hooks:
+      - id: yamlfmt
 
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.5.0
-      hooks:
-          - id: trailing-whitespace
-          - id: check-added-large-files
-          - id: check-case-conflict
-          - id: check-merge-conflict
-          - id: check-shebang-scripts-are-executable
-          - id: check-symlinks
-          - id: check-toml
-          - id: check-yaml
-          - id: check-json
-          - id: detect-private-key
-          - id: end-of-file-fixer
-          - id: pretty-format-json
-            args: [--autofix]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: check-symlinks
+      - id: check-toml
+      - id: check-yaml
+      - id: check-json
+      - id: detect-private-key
+      - id: end-of-file-fixer
+      - id: pretty-format-json
+        args: [--autofix]
 
-    - repo: https://github.com/jumanjihouse/pre-commit-hooks
-      rev: 3.0.0
-      hooks:
-          - id: git-check # Configure in .gitattributes
-          - id: git-dirty # Configure in .gitignore
-          - id: script-must-have-extension
+  - repo: https://github.com/jumanjihouse/pre-commit-hooks
+    rev: 3.0.0
+    hooks:
+      - id: git-check # Configure in .gitattributes
+      - id: git-dirty # Configure in .gitignore
+      - id: script-must-have-extension
 
 
-    - repo: https://github.com/gruntwork-io/pre-commit
-      rev: v0.1.23
-      hooks:
-          - id: shellcheck
+  - repo: https://github.com/gruntwork-io/pre-commit
+    rev: v0.1.23
+    hooks:
+      - id: shellcheck
 
-    - repo: https://github.com/mineiros-io/pre-commit-hooks
-      rev: v0.5.1
-      hooks:
-          - id: terraform-fmt
-            files: ^(modules|examples)/.+(\.tf|\.hcl)$
-          - id: terraform-validate
-            files: ^(modules|examples)/.+(\.tf|\.hcl)$
+  - repo: https://github.com/mineiros-io/pre-commit-hooks
+    rev: v0.5.1
+    hooks:
+      - id: terraform-fmt
+        files: ^(modules|examples)/.+(\.tf|\.hcl)$
+      - id: terraform-validate
+        files: ^(modules|examples)/.+(\.tf|\.hcl)$
 
-    - repo: https://github.com/mineiros-io/pre-commit-hooks
-      rev: v0.5.1
-      hooks:
-          - id: terraform-fmt
-            files: ^tests/.+\.tf$
-          - id: terraform-validate
-            files: ^tests/.+\.tf$
+  - repo: https://github.com/mineiros-io/pre-commit-hooks
+    rev: v0.5.1
+    hooks:
+      - id: terraform-fmt
+        files: ^tests/.+\.tf$
+      - id: terraform-validate
+        files: ^tests/.+\.tf$
 
-    - repo: https://github.com/dnephin/pre-commit-golang
-      rev: v0.5.1
-      hooks:
-          - id: go-fmt
-            files: ^tests/(.*/)*.*\.go$
-          - id: go-mod-tidy
-            files: ^tests/(.*/)*.*\.go$
+  - repo: https://github.com/dnephin/pre-commit-golang
+    rev: v0.5.1
+    hooks:
+      - id: go-fmt
+        files: ^tests/(.*/)*.*\.go$
+      - id: go-mod-tidy
+        files: ^tests/(.*/)*.*\.go$
 
-    - repo: https://github.com/igorshubovych/markdownlint-cli
-      rev: v0.39.0
-      hooks:
-          - id: markdownlint-fix
-            args: [.]
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.39.0
+    hooks:
+      - id: markdownlint-fix
+        args: [.]
 
-    - repo: https://github.com/antonbabenko/pre-commit-terraform
-      rev: v1.88.2
-      hooks:
-          - id: terraform_tflint
-            name: Terraform tflint
-            entry: >
-                sh -c 'find modules examples -type f -name ".tflint.hcl" -print0 |
-                xargs -0 -I{} sh -c "tflint --init --config={} \$(dirname {})" || echo "Skipping, no .tflint.hcl found"'
-            files: ^(modules|examples)/.*/.*\.(tf|hcl)$
-            language: system
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: v1.88.2
+    hooks:
+      - id: terraform_tflint
+        name: Terraform tflint
+        entry: >
+          sh -c 'find modules examples -type f -name ".tflint.hcl" -print0 |
+          xargs -0 -I{} sh -c "tflint --init --config={} \$(dirname {})" || echo "Skipping, no .tflint.hcl found"'
+        files: ^(modules|examples)/.*/.*\.(tf|hcl)$
+        language: system
 
-    - repo: https://github.com/tcort/markdown-link-check
-      rev: v3.12.1
-      hooks:
-          - id: markdown-link-check
-            args:
-                - -q
-                - --config=.markdown-link-check.json
+  - repo: https://github.com/tcort/markdown-link-check
+    rev: v3.12.1
+    hooks:
+      - id: markdown-link-check
+        args:
+          - -q
+          - --config=.markdown-link-check.json
 
-    - repo: https://github.com/terraform-docs/terraform-docs
-      rev: v0.17.0
-      hooks:
-          - id: terraform-docs-go
-            files: ^(modules|examples)/.*/.*\.(tf|hcl)$
-            entry: >
-                sh -c 'find modules examples -type f -name ".terraform-docs.yml" -print0 |
-                xargs -0 -I{} sh -c "terraform-docs markdown --config={} --output-file \$(dirname {})/README.md --output-mode inject \$(dirname {})" ||
-                echo "Skipping, no .terraform-docs.yml found"'
-            language: system
+  - repo: https://github.com/terraform-docs/terraform-docs
+    rev: v0.17.0
+    hooks:
+      - id: terraform-docs-go
+        files: ^(modules|examples)/.*/.*\.(tf|hcl)$
+        entry: >
+          sh -c 'find modules examples -type f -name ".terraform-docs.yml" -print0 |
+          xargs -0 -I{} sh -c "terraform-docs markdown --config={} --output-file \$(dirname {})/README.md --output-mode inject \$(dirname {})" ||
+          echo "Skipping, no .terraform-docs.yml found"'
+        language: system
 
-    - repo: https://github.com/golangci/golangci-lint
-      rev: v1.56.2
-      hooks:
-          - id: golangci-lint
-            args: [--config=../../.golangci.yml] # Default config path relative to the test directories.
-            entry: >
-                sh -c 'find tests -type f -name "go.mod" -print0 |
-                xargs -0 -I{} sh -c "module_dir=\$(dirname {}); root_dir=\$(git rev-parse --show-toplevel); echo \"Running golangci-lint in \$module_dir\";
-                (cd \$module_dir && golangci-lint run --config=\$root_dir/.golangci.yml ./...)" || echo "Skipping, no go.mod found"'
-            language: system
+  - repo: https://github.com/golangci/golangci-lint
+    rev: v1.56.2
+    hooks:
+      - id: golangci-lint
+        args: [--config=../../.golangci.yml] # Default config path relative to the test directories.
+        entry: >
+          sh -c 'find tests -type f -name "go.mod" -print0 |
+          xargs -0 -I{} sh -c "module_dir=\$(dirname {}); root_dir=\$(git rev-parse --show-toplevel); echo \"Running golangci-lint in \$module_dir\";
+          (cd \$module_dir && golangci-lint run --config=\$root_dir/.golangci.yml ./...)" || echo "Skipping, no go.mod found"'
+        language: system


### PR DESCRIPTION
Updated pre-commit hooks versions for yamllint, yamlfmt, trailing-whitespace,
check-added-large-files, check-case-conflict, check-merge-conflict,
check-shebang-scripts-are-executable, check-symlinks, check-toml, check-yaml,
check-json, detect-private-key, end-of-file-fixer, pretty-format-json, git-check,
git-dirty, script-must-have-extension, shellcheck, terraform-fmt,
terraform-validate, go-fmt, go-mod-tidy, markdownlint-fix, and terraform_tflint.