### PR TITLE
feat: Add Makefile to example modules for consistent testing

### DIFF
--- a/docs/terraform-styleguide/terraform-styleguide-examples.md
+++ b/docs/terraform-styleguide/terraform-styleguide-examples.md
@@ -9,6 +9,7 @@
     - [Rule: Core Directory Layout](#rule-core-directory-layout)
     - [Rule: General rules when implementing examples](#rule-general-rules-when-implementing-examples)
     - [Rule: Naming Conventions for examples](#rule-naming-conventions-for-examples)
+    - [Rule: Makefile Implementation](#rule-makefile-implementation)
     - [Rule: Basic Example](#rule-basic-example)
     - [Rule: Complete Example](#rule-complete-example)
 
@@ -30,6 +31,7 @@ This document provides comprehensive guidelines for creating example modules in 
 │   ├── outputs.tf         # Example outputs
 │   ├── versions.tf        # Provider and Terraform version constraints
 │   ├── providers.tf       # Provider configurations
+│   ├── Makefile           # Commands for quickly testing different scenarios
 │   ├── .terraform-docs.yml # Documentation generation configuration
 │   ├── .tflint.hcl        # Terraform linting rules
 │   └── fixtures/
@@ -41,6 +43,7 @@ This document provides comprehensive guidelines for creating example modules in 
 │   ├── outputs.tf
 │   ├── versions.tf
 │   ├── providers.tf
+│   ├── Makefile           # Commands for quickly testing different scenarios
 │   ├── .terraform-docs.yml # Documentation generation configuration
 │   ├── .tflint.hcl        # Terraform linting rules
 │   └── fixtures/
@@ -52,6 +55,7 @@ This document provides comprehensive guidelines for creating example modules in 
     ├── outputs.tf
     ├── versions.tf
     ├── providers.tf
+    ├── Makefile           # Commands for quickly testing different scenarios
 │   ├── .terraform-docs.yml # Documentation generation configuration
 │   ├── .tflint.hcl        # Terraform linting rules
     └── fixtures/
@@ -91,6 +95,142 @@ module "this" {
   }
 }
 ```
+
+### Rule: Makefile Implementation
+
+**Purpose**: Provide standardized, consistent commands for quickly testing different scenarios using the example's fixtures.
+
+- ALWAYS include a Makefile in each example directory with standardized commands for testing the module.
+- ALWAYS structure the Makefile with clear sections for init, plan, apply, destroy, cycle, and utility commands.
+- ALWAYS include commands for each fixture variant in the example's fixtures directory.
+- ALWAYS include a comprehensive help command as the default target.
+- ALWAYS define commands that follow the pattern `[action]-[fixture]` (e.g., `plan-default`, `apply-disabled`, etc.).
+
+The Makefile should follow this structure:
+
+```makefile
+# Makefile for [MODULE NAME] - [EXAMPLE TYPE] Example
+# This file provides quick commands for testing the module
+
+# Default AWS region if not specified
+AWS_REGION ?= us-west-2
+
+.PHONY: help init \
+        plan-default plan-disabled [additional-plan-commands] \
+        apply-default apply-disabled [additional-apply-commands] \
+        destroy-default destroy-disabled [additional-destroy-commands] \
+        cycle-default cycle-disabled [additional-cycle-commands] \
+        clean
+
+# Default target when just running 'make'
+help:
+	@echo "[MODULE NAME] - [EXAMPLE TYPE] Example"
+	@echo ""
+	@echo "Available commands:"
+	@echo "  make init                 - Initialize Terraform"
+	@echo ""
+	@echo "  Plan commands (terraform plan):"
+	@echo "  make plan-default         - Plan with default configuration"
+	@echo "  make plan-disabled        - Plan with module entirely disabled"
+	# List additional plan commands here
+	@echo ""
+	@echo "  Apply commands (terraform apply):"
+	@echo "  make apply-default        - Apply with default configuration"
+	@echo "  make apply-disabled       - Apply with module entirely disabled"
+	# List additional apply commands here
+	@echo ""
+	@echo "  Destroy commands (terraform destroy):"
+	@echo "  make destroy-default      - Destroy resources with default configuration"
+	@echo "  make destroy-disabled     - Destroy resources with module entirely disabled"
+	# List additional destroy commands here
+	@echo ""
+	@echo "  Complete cycle commands (plan, apply, and destroy):"
+	@echo "  make cycle-default        - Run full cycle with default configuration"
+	@echo "  make cycle-disabled       - Run full cycle with module entirely disabled"
+	# List additional cycle commands here
+	@echo ""
+	@echo "  Utility commands:"
+	@echo "  make clean                - Remove .terraform directory and other Terraform files"
+	@echo ""
+	@echo "Environment variables:"
+	@echo "  AWS_REGION                - AWS region to deploy resources (default: us-west-2)"
+
+# Initialize Terraform
+init:
+	@echo "Initializing Terraform..."
+	terraform init
+
+# Plan commands
+plan-default: init
+	@echo "Planning with default fixture..."
+	terraform plan -var-file=fixtures/default.tfvars
+
+plan-disabled: init
+	@echo "Planning with disabled fixture (module entirely disabled)..."
+	terraform plan -var-file=fixtures/disabled.tfvars
+
+# Additional plan commands for specific fixtures
+# plan-[feature]-disabled: init
+#	@echo "Planning with [feature] component disabled..."
+#	terraform plan -var-file=fixtures/[feature]-disabled.tfvars
+
+# Apply commands
+apply-default: init
+	@echo "Applying with default fixture..."
+	terraform apply -var-file=fixtures/default.tfvars -auto-approve
+
+apply-disabled: init
+	@echo "Applying with disabled fixture (module entirely disabled)..."
+	terraform apply -var-file=fixtures/disabled.tfvars -auto-approve
+
+# Additional apply commands for specific fixtures
+# apply-[feature]-disabled: init
+#	@echo "Applying with [feature] component disabled..."
+#	terraform apply -var-file=fixtures/[feature]-disabled.tfvars -auto-approve
+
+# Destroy commands
+destroy-default: init
+	@echo "Destroying resources with default fixture..."
+	terraform destroy -var-file=fixtures/default.tfvars -auto-approve
+
+destroy-disabled: init
+	@echo "Destroying resources with disabled fixture (module entirely disabled)..."
+	terraform destroy -var-file=fixtures/disabled.tfvars -auto-approve
+
+# Additional destroy commands for specific fixtures
+# destroy-[feature]-disabled: init
+#	@echo "Destroying resources with [feature] component disabled..."
+#	terraform destroy -var-file=fixtures/[feature]-disabled.tfvars -auto-approve
+
+# Run full cycle commands
+cycle-default: plan-default apply-default destroy-default
+	@echo "Completed full cycle with default fixture"
+
+cycle-disabled: plan-disabled apply-disabled destroy-disabled
+	@echo "Completed full cycle with disabled fixture (module entirely disabled)"
+
+# Additional cycle commands for specific fixtures
+# cycle-[feature]-disabled: plan-[feature]-disabled apply-[feature]-disabled destroy-[feature]-disabled
+#	@echo "Completed full cycle with [feature] component disabled"
+
+# Clean up Terraform files
+clean:
+	@echo "Cleaning up Terraform files..."
+	rm -rf .terraform .terraform.lock.hcl terraform.tfstate terraform.tfstate.backup .terraform.tfstate.lock.info
+	@echo "Cleanup complete"
+```
+
+For modules with component-specific feature flags like the foundation module example, include additional commands for each feature flag variation:
+
+- Commands for components that can be individually disabled (e.g., `plan-kms-disabled`, `apply-s3-disabled`)
+- Full cycle commands for each component variation (e.g., `cycle-logs-disabled`)
+
+These fixtures should match the module's capabilities and feature flags, and should always include at minimum:
+- `default.tfvars` - Default configuration with all features enabled
+- `disabled.tfvars` - Configuration with the entire module disabled (`is_enabled = false`)
+- Additional fixtures for each significant configuration variation
+
+The Makefile provides a consistent interface for users to experiment with different module configurations, making it easier to understand the module's behavior under various scenarios without having to remember complex Terraform command-line options.
 
 ### Rule: Basic Example
 

--- a/docs/terraform-styleguide/terraform-styleguide-modules.md
+++ b/docs/terraform-styleguide/terraform-styleguide-modules.md
@@ -141,6 +141,7 @@ examples
         ├── providers.tf
         ├── variables.tf
         └── versions.tf
+        ├── Makefile
         ├── .terraform-docs.yml
         └── .tflint.hcl
     └── complete


### PR DESCRIPTION
Here is the pull request description based on the provided context:

## 🎯 What
* ❓ Added a Makefile to each example module directory to provide a standardized set of commands for quickly testing different scenarios using the example's fixtures.
* 🎉 Users can now easily test the example modules by running the provided Makefile commands, which follow a consistent naming convention (e.g., `plan-default`, `apply-disabled`, etc.). This makes it easier to understand the module's behavior under various scenarios.

## 🤔 Why
* 💡 The changes were made to provide a consistent, standardized way for users to test the example modules.
* 🎯 This will make it easier for users to understand and use the available commands, without having to remember complex Terraform command-line options.

## 📚 References
* 🔗 This PR is related to the changes described in the commit message.