### PR TITLE
fix: Initialize TFLint before running it in Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -286,6 +286,7 @@ tf-lint MOD='':
         for dir in $(find modules examples -type f -name ".tflint.hcl" | xargs -I {} dirname {}); do \
             echo "🕵️ Linting directory: $dir"; \
             cd $dir && \
+            tflint --init && \
             tflint --recursive && \
             cd - > /dev/null; \
         done \
@@ -299,6 +300,7 @@ tf-lint MOD='':
         for example_dir in $(find "{{EXAMPLES_DIR}}/{{MOD}}" -type f -name ".tflint.hcl" | xargs -I {} dirname {} | sort -u); do \
             echo "   📂 Linting example directory: $example_dir"; \
             cd "$example_dir" && \
+            tflint --init && \
             tflint --recursive && \
             cd - > /dev/null; \
         done; \
@@ -311,20 +313,20 @@ tf-lint-nix MOD='':
         for dir in $(find modules examples -type f -name ".tflint.hcl" | xargs -I {} dirname {}); do \
             echo "🕵️ Linting directory: $dir"; \
             cd $dir && \
-            nix develop . --impure --extra-experimental-features nix-command --extra-experimental-features flakes --command tflint --recursive && \
+            nix develop . --impure --extra-experimental-features nix-command --extra-experimental-features flakes --command bash -c 'tflint --init && tflint --recursive' && \
             cd - > /dev/null; \
         done \
     else \
         echo "🕵️ Linting module directory: {{MODULES_DIR}}/{{MOD}}"; \
         cd "{{MODULES_DIR}}/{{MOD}}" && \
-        nix develop . --impure --extra-experimental-features nix-command --extra-experimental-features flakes --command tflint --recursive && \
+        nix develop . --impure --extra-experimental-features nix-command --extra-experimental-features flakes --command bash -c 'tflint --init && tflint --recursive' && \
         cd - > /dev/null; \
         \
         echo "🕵️ Linting example subdirectories for module: {{MOD}}"; \
         for example_dir in $(find "{{EXAMPLES_DIR}}/{{MOD}}" -type f -name ".tflint.hcl" | xargs -I {} dirname {} | sort -u); do \
             echo "   📂 Linting example directory: $example_dir"; \
             cd "$example_dir" && \
-            nix develop . --impure --extra-experimental-features nix-command --extra-experimental-features flakes --command tflint --recursive && \
+            nix develop . --impure --extra-experimental-features nix-command --extra-experimental-features flakes --command bash -c 'tflint --init && tflint --recursive' && \
             cd - > /dev/null; \
         done; \
     fi


### PR DESCRIPTION
Here is the pull request description based on the provided context:

## 🎯 What
* ❓ Initialized TFLint before running it in the Justfile.
* 🎉 This ensures that the TFLint configuration is properly set up before running the linter, preventing potential failures.

## 🤔 Why
* 💡 The changes were made to fix an issue where the Justfile was running the `tflint --recursive` command directly, which could fail if the `.tflint.hcl` configuration file was not present.
* 🎯 This change will make the TFLint linter more reliable and ensure that it can run successfully in the project.

## 📚 References
* 🔗 This PR addresses the issue described in the commit messages.