### PR TITLE
docs: fix trailing whitespace in markdown guides

### DIFF
--- a/docs/guides/environment_variables.md
+++ b/docs/guides/environment_variables.md
@@ -17,7 +17,7 @@ This guide provides comprehensive documentation for all Terraform environment va
 
 ## Quick Start
 
-This project uses Justfile with `set dotenv-load` to automatically load environment variables from `.env` files. 
+This project uses Justfile with `set dotenv-load` to automatically load environment variables from `.env` files.
 
 1. Copy `.env.example` to `.env`
 2. Uncomment and set required variables
@@ -443,7 +443,7 @@ Terraform uses the following precedence order (highest to lowest):
    ```justfile
    # The `set dotenv-load` directive automatically loads .env files
    set dotenv-load
-   
+
    terraform-plan env="development":
        @echo "Planning for {{env}} environment"
        terraform plan
@@ -565,6 +565,6 @@ gcloud config get-value project
 
 ---
 
-**Last Updated**: January 2025  
-**Terraform Version**: 1.12.x  
-**Sources**: Official HashiCorp documentation, AWS provider docs, community best practices 
+**Last Updated**: January 2025
+**Terraform Version**: 1.12.x
+**Sources**: Official HashiCorp documentation, AWS provider docs, community best practices

--- a/docs/guides/justfile-recipes-guide.md
+++ b/docs/guides/justfile-recipes-guide.md
@@ -177,4 +177,4 @@ Using `just dev` provides an interactive shell with all necessary tools loaded, 
 - Leverage the `-f <Justfile>` option if you have multiple Justfiles (though typically you'll only have one in the project root).
 - Combine recipes using dependencies for complex workflows (see the Justfile for examples like `tf-validate` or `go-ci`).
 
-This guide should provide new contributors with a solid understanding of how to use the Justfile recipes to streamline their development workflow. 
+This guide should provide new contributors with a solid understanding of how to use the Justfile recipes to streamline their development workflow.

--- a/docs/guides/pipeline-guide.md
+++ b/docs/guides/pipeline-guide.md
@@ -377,14 +377,14 @@ graph TD
     A[is-tf-module] --> B[module-convention-check]
     A --> C[static-analysis]
     A --> D[module-docs-verification]
-    
+
     B --> E[module-lint]
     C --> E
     D --> E
-    
+
     E --> F[module-versions-compatibility-check]
     F --> G[module-build]
-    
+
     G --> H[summary]
     E --> H
     F --> H
@@ -428,7 +428,7 @@ on:
    ```bash
    # Initialize pipeline
    just pipeline-infra-build
-   
+
    # Open interactive shell for debugging
    just pipeline-infra-shell
    ```
@@ -437,7 +437,7 @@ on:
    ```bash
    # Test static analysis
    just pipeline-action-terraform-static-analysis default
-   
+
    # Test with custom module
    just pipeline-action-terraform-static-analysis my-module
    ```
@@ -673,4 +673,4 @@ dagger call with-terragrunt --version="0.45.0"
 dagger call with-terraform-init --providers-only=true
 ```
 
-This comprehensive guide should help you understand and effectively use the Dagger pipeline for Terraform module development and CI/CD operations. 
+This comprehensive guide should help you understand and effectively use the Dagger pipeline for Terraform module development and CI/CD operations.


### PR DESCRIPTION
Remove trailing whitespace from multiple markdown guide files to improve
consistency and adhere to formatting best practices.

This change affects the following files:
- docs/guides/environment_variables.md
- docs/guides/pipeline-guide.md
- docs/guides/justfile-recipes-guide.md

Trailing spaces were present at the end of several lines, which can cause
unnecessary diffs, interfere with some markdown renderers, and reduce
overall document cleanliness. The fix involves deleting these trailing
spaces without altering any content or formatting.

No functional or behavioral changes are introduced by this commit, as it
only modifies whitespace in documentation files. This cleanup helps maintain
a consistent style and prevents potential issues with markdown parsers or
tooling that may be sensitive to trailing whitespace.

No backwards compatibility concerns apply since only documentation is
affected. This change aligns with common documentation hygiene practices
and improves the quality of the project’s markdown sources.